### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ sudo chmod a+x /usr/bin/tinywm-session
 tinwm-session preloads a terminal and then runs the go binary. Build the binary and move it to /usr/bin/.
 
 ```
-$ go build
+$ go build tinywm.go
 $ sudo mv tinywm /usr/bin/
 $ sudo chmod a+x /usr/bin/tinywm
 ```


### PR DESCRIPTION
you must compile the file **tinywm.go** otherwise it will send an error that `go mod init` was not executed.